### PR TITLE
quick fix for firefox -> NS_ERROR_FAILURE

### DIFF
--- a/app/Widgets/GraphWidget/js/sw.graphwidget.js
+++ b/app/Widgets/GraphWidget/js/sw.graphwidget.js
@@ -2528,7 +2528,14 @@
       graph_title
           .attr('x', widget.graph.x.range()[1] / 2)
           .attr('y', (widget.graph.margin.bottom - widget.graph.y.range()[0] / 2) - (graph_title.node().getBBox().height / 2));
-      var splits = parseInt(graph_title.node().getBBox().width / widget.svg.select('defs').select('rect').node().getBBox().width);
+      var svg_rect_node = widget.svg.select('defs').select('rect').node();
+      var svg_rect_width;
+      try {
+        svg_rect_width = svg_rect_node.getBBox().width;
+      } catch(err) {
+        svg_rect_width = svg_rect_node.width.animVal.value;
+      }
+      var splits = parseInt(graph_title.node().getBBox().width / svg_rect_width);
       if (splits > 0)
       {
         var graph_title_atoms = widget.query_data.title.split(' ');


### PR DESCRIPTION
firefox trows an NS_ERROR_FAILURE while trying to execute getBBox on the svg element, this is a cheap workaround

for details see -> https://bugzilla.mozilla.org/show_bug.cgi?id=612118
