### PR TITLE
Search widgets now provide tag suggestions once the metric has been determined

### DIFF
--- a/app/Widgets/GraphWidget/css/sw.graphwidget.css
+++ b/app/Widgets/GraphWidget/css/sw.graphwidget.css
@@ -118,6 +118,15 @@
 
 .metric-input-textbox {
     width: 100%;
+    position: relative;
+}
+
+.metric-input-textbox .tag-suggestions {
+    position: absolute;
+    top: -25px;
+    right: 5%;
+    margin: 0;
+    text-align: right;
 }
 
 .metric-autocomplete {
@@ -245,3 +254,4 @@ path.line {
     fill: rgba(64, 64, 64, 0.5);
     shape-rendering: crispEdges;
 }
+


### PR DESCRIPTION
Re: #25

Some points to note:
- The way we get the tags is through a token 1 hour query of the metric. This makes me cringe a little but works OK in practice for our metrics.
- The caching is done via a global javascript Object. Each time an user refreshes the page / navigates to a new one, this cache is reset. Not sure if using sessionStorage is a better call.
