### PR TITLE
Date.js

### DIFF
--- a/setup_requirements.sh
+++ b/setup_requirements.sh
@@ -46,4 +46,4 @@ rm bootstrap.zip
 ln -s bootstrap.min.js bootstrap.js
 
 # Get DateJS
-/usr/bin/wget https://datejs.googlecode.com/files/date.js
+/usr/bin/wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/datejs/date.js


### PR DESCRIPTION
Data.js URL was not working. Simply put this new URL into this file:

https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/datejs/date.js